### PR TITLE
Merge effect size FAQ and clean up citations

### DIFF
--- a/effectsize_example.Rmd
+++ b/effectsize_example.Rmd
@@ -24,7 +24,7 @@ Broadly speaking, an effect size is "anything that might be of interest" [@Cummi
 
 In HCI, common examples of effect size include the mean difference (e.g., in seconds) in task completion times between two techniques, or the mean difference in error rates (e.g., in percent). These are called *simple effect sizes* (or *unstandardized effect sizes*).
 
-More complex measures of effect size exist called *standardized effect sizes* (see [What is a standardized effect size?](#faq_standarized)). Although the term *effect size* is often used to refer to standardized effect sizes only, using the term in a broader sense can avoid unnecessary confusion [@Cumming2013a, @Wilkinson1999a]. In this document, "effect size" refers to both simple and standardized effect sizes.
+More complex measures of effect size exist called *standardized effect sizes* (see [What is a standardized effect size?](#faq_standarized)). Although the term *effect size* is often used to refer to standardized effect sizes only, using the term in a broader sense can avoid unnecessary confusion [@Cumming2013a; @Wilkinson1999a]. In this document, "effect size" refers to both simple and standardized effect sizes.
 
 
 <a id="faq_when_why"></a>
@@ -79,7 +79,7 @@ Standardized effect sizes are useful in some situations, for example when effect
 
 In most cases, simple effect sizes should be preferred over standardized effect sizes:
 
-> Only rarely will uncorrected standardized effect size be more useful than simple effect size. It is usually far better to report simple effect size. [@baguley2009standardized]
+> Only rarely will uncorrected standardized effect size be more useful than simple effect size. It is usually far better to report simple effect size. [@Baguley2009]
 
 Simple effect sizes are often easier to interpret and justify [@Cumming2014a; @Cummings2011]. When the units of the data are meaningful (e.g., seconds), reporting effect sizes expressed in their original units is more informative and can make it easier to judge whether the effect has a practical significance [@Wilkinson1999a; @Cummings2011].
 

--- a/effectsize_example.Rmd
+++ b/effectsize_example.Rmd
@@ -19,18 +19,18 @@ TODO: generate the teaser figure in code
 
 ## What is an effect size?
 
-Broadly speaking, an effect size is *"anything that might be of interest"* [@Cumming2013a]; it is some quantity that captures the magnitude of the effect studied.
+Broadly speaking, an effect size is "anything that might be of interest" [@Cumming2013a]; it is some quantity that captures the magnitude of the effect studied.
 
 In HCI, common examples of effect size include the mean difference (e.g., in seconds) in task completion times between two techniques, or the mean difference in error rates (e.g., in percent). These are called *simple effect sizes* (or *unstandardized effect sizes*).
 
-More complex measures of effect size exist called *standardized effect sizes* (see [What is a standardized effect size?](#faq_standarized)). Although the term "effect size" is often used to refer to standardized effect sizes only, using the term in a broader sense can avoid unnecessary confusion [@Cumming2013a, @Wilkinson1999a]. In this document, "effect size" refers to both simple and standardized effect sizes.
+More complex measures of effect size exist called *standardized effect sizes* (see [What is a standardized effect size?](#faq_standarized)). Although the term *effect size* is often used to refer to standardized effect sizes only, using the term in a broader sense can avoid unnecessary confusion [@Cumming2013a, @Wilkinson1999a]. In this document, "effect size" refers to both simple and standardized effect sizes.
 
 
 <a id="faq_when_why"></a>
 
 ## Why and when should effect sizes be reported?
 
-In quantitative experiments, effect sizes are among the most elementary and the most essential summary statistics that can be reported. Identifying the effect size(s) of interest also allows the researcher to turn a vague research question into a precise, quantitative question [@Cumming2014a]. For example, if a researcher is interested in showing that her technique is faster than a baseline technique, an appropriate choice of effect size is the mean difference in completion times. The observed effect size will indicate not only the likely direction of the effect (e.g., whether the technique is faster), but also whether the effect is large enough to care about. 
+In quantitative experiments, effect sizes are among the most elementary and essential summary statistics that can be reported. Identifying the effect size(s) of interest also allows the researcher to turn a vague research question into a precise, quantitative question [@Cumming2014a]. For example, if a researcher is interested in showing that their technique is faster than a baseline technique, an appropriate choice of effect size is the mean difference in completion times. The observed effect size will indicate not only the likely direction of the effect (e.g., whether the technique is faster or slower), but also whether the effect is large enough to care about. 
 
 For the sake of transparency, effect sizes should always be reported in quantitative research, unless there are good reasons not to do so. According to the American Psychological Association:
 
@@ -45,7 +45,7 @@ Sometimes, effect sizes can be hard to compute or to interpret. When this is the
 
 The first choice is on whether to report simple effect sizes or standardized effect sizes. For this question, see [Should simple effect sizes or standardized effect sizes be reported?](#faq_simple_v_standardized) 
 
-It is rarely sufficient to report an effect size as a single quantity. This is because a single quantity like a difference in means or a Cohen's *d* is typically only a *point estimate*, i.e., it is merely a “best guess” of the true effect size. It is crucial to also assess and report the statistical uncertainty about this point estimate.
+It is rarely sufficient to report an effect size as a single quantity. This is because a single quantity like a difference in means or a Cohen's *d* is typically only a *point estimate*, i.e., it is merely a best guess of the true effect size. It is crucial to also assess and report the statistical uncertainty about this point estimate.
 
 For more on assessing and reporting statistical uncertainty, see the [inferential statistics FAQ]().
 
@@ -65,7 +65,7 @@ This information can be reported either numerically or graphically. Both formats
 
 ## What is a standardized effect size?
 
-A standardized effect size is a unitless measure of effect size. The most common measure of standardized effect size is Cohen’s *d*, where the mean difference is divided by the standard deviation of the pooled observations [@Cohen1988a]. [Other approaches](http://stats.idre.ucla.edu/other/mult-pkg/faq/general/effect-size-power/faqhow-is-effect-size-used-in-power-analysis/) to standardization exist [prefer citations]. To some extent, standardized effect sizes make it possible to compare different studies in terms of how “impressive” their results are (see [How do I know my effect is large enough?](#faq_large_enough)).
+A standardized effect size is a unitless measure of effect size. The most common measure of standardized effect size is Cohen’s *d*, where the mean difference is divided by the standard deviation of the pooled observations [@Cohen1988a]. [Other approaches](http://stats.idre.ucla.edu/other/mult-pkg/faq/general/effect-size-power/faqhow-is-effect-size-used-in-power-analysis/) to standardization exist [prefer citations]. To some extent, standardized effect sizes make it possible to compare different studies in terms of how “impressive” their results are (see [How do I know my effect is large enough?](#faq_large_enough)); however, this practice is not without criticism (see the section *Standardized mean differences let us compare and summarize results when studies use different outcome scales* of [@Cummings2011]).
 
 
 <a id="faq_simple_v_standardized"></a>
@@ -226,7 +226,7 @@ To illustrate the effect of domain on interpreting effect size, we will imagine 
 
 Imagine the above study was from the comparison of a novel physical user interface prototyping system (treatment `B`) to the previous state of the art (`A`), and the completion time referred to the time for feedback to be given to the user after they perform an input action. We might report the following interpretation of the results:
 
-> Technique `B` offers a **large** improvement in feedback time (~`r format_num(t_result$conf.low, 2)`--`r format_num(t_result$conf.high, 2)`ms mean decrease), resulting in feedback times that tend to be less than the threshold of human perception (less than about 100ms). By contrast, the larger feedback times offered by technique `A` tended to be above that threshold, possibly degrading users' experience of the prototypes built using that technique.
+> Technique `B` offers a **large** improvement in feedback time (~`r format_num(t_result$conf.low, 2)` -- `r format_num(t_result$conf.high, 2)`ms mean decrease), resulting in feedback times that tend to be less than the threshold of human perception (less than about 100ms). By contrast, the larger feedback times offered by technique `A` tended to be above that threshold, possibly degrading users' experience of the prototypes built using that technique.
 
 
 ### Domain 2: Chatbots

--- a/effectsize_example.Rmd
+++ b/effectsize_example.Rmd
@@ -119,7 +119,7 @@ is to be gained than lost by supplying a common conventional frame of
 reference which is recommended for use only when no better basis for estimating
 the ES index is available. [@Cohen1977]
 
-Cohen recommended the use of these thresholds only when no better frame of reference for assessing practical importance was available. However, hindsight has demonstrated that if such thresholds are offered, they will be adopted as a convenience, often without much thought to how they apply to the domain at hand [citation needed]. Once adopted, these thresholds make reports more opaque, by standardizing away units of measurement and categorizing results into arbitrary classes. Like Cummings [@Cummings2011], we recommend against assessing the importance of effects by labeling them using Cohen's thresholds.
+Cohen recommended the use of these thresholds only when no better frame of reference for assessing practical importance was available. However, hindsight has demonstrated that if such thresholds are offered, they will be adopted as a convenience, often without much thought to how they apply to the domain at hand [@Baguley2004; @Lenth2001]; Lenth has called this usage "canned effect sizes" [@Lenth2001]. Once adopted, these thresholds make reports more opaque, by standardizing away units of measurement and categorizing results into arbitrary classes. Like Cummings [@Cummings2011], we recommend against assessing the importance of effects by labeling them using Cohen's thresholds.
 
 
 <a id="exemplar_simple_effect_size"></a>

--- a/effectsize_example.Rmd
+++ b/effectsize_example.Rmd
@@ -6,6 +6,7 @@ output:
     toc_float:
       collapsed: yes
 bibliography: references.bib
+link-citations: true
 ---
 
 <div style="text-align:center">
@@ -80,7 +81,7 @@ In most cases, simple effect sizes should be preferred over standardized effect 
 
 > Only rarely will uncorrected standardized effect size be more useful than simple effect size. It is usually far better to report simple effect size. [@baguley2009standardized]
 
-Simple effect sizes are often easier to interpret and justify [@Cumming2014a; @Cummings2011]. When the units of the data are meaningful (e.g., seconds), reporting effect sizes expressed in their original units is more informative and can make it easier to judge whether the effect has a practical significance [@Wilkinson1999a,@Cummings2011].
+Simple effect sizes are often easier to interpret and justify [@Cumming2014a; @Cummings2011]. When the units of the data are meaningful (e.g., seconds), reporting effect sizes expressed in their original units is more informative and can make it easier to judge whether the effect has a practical significance [@Wilkinson1999a; @Cummings2011].
 
 Barring a strong, domain- or problem-specific argument for reporting a standardized effect size instead of a simple one, simple effect sizes should be preferred as being more transparent and easier to interpret.
 
@@ -119,7 +120,7 @@ is to be gained than lost by supplying a common conventional frame of
 reference which is recommended for use only when no better basis for estimating
 the ES index is available. [@Cohen1977]
 
-Cohen recommended the use of these thresholds only when no better frame of reference for assessing practical importance was available. However, hindsight has demonstrated that if such thresholds are offered, they will be adopted as a convenience, often without much thought to how they apply to the domain at hand [@Baguley2004; @Lenth2001]; Lenth has called this usage "canned effect sizes" [@Lenth2001]. Once adopted, these thresholds make reports more opaque, by standardizing away units of measurement and categorizing results into arbitrary classes. Like Cummings [@Cummings2011], we recommend against assessing the importance of effects by labeling them using Cohen's thresholds.
+Cohen recommended the use of these thresholds only when no better frame of reference for assessing practical importance was available. However, hindsight has demonstrated that if such thresholds are offered, they will be adopted as a convenience, often without much thought to how they apply to the domain at hand [@Baguley2004; @Lenth2001]; Lenth has called this usage "canned effect sizes" [@Lenth2001]. Once adopted, these thresholds make reports more opaque, by standardizing away units of measurement and categorizing results into arbitrary classes. Like Cummings [-@Cummings2011], we recommend against assessing the importance of effects by labeling them using Cohen's thresholds.
 
 
 <a id="exemplar_simple_effect_size"></a>
@@ -361,7 +362,7 @@ data <-
 
 
 ## Compute effect sizes
-While **Cohen's *d* ** is often used for simple 2-factor, single-trial, between-subject designs, more complex designs can be more consistently interpretted with the **eta squared ($\eta^{2}$)** family of effect sizes, which represent the proportion of variance accounted for by a particular variable. A variant, **generalized eta squared ($\eta_{G}^{2}$)**, is particularly suited for providing comparable effect sizes in both between and within-subject designs [@Olejnik2003, @Bakeman2005]. This property makes it more easily applicable to meta-analyses.
+While **Cohen's *d* ** is often used for simple 2-factor, single-trial, between-subject designs, more complex designs can be more consistently interpretted with the **eta squared ($\eta^{2}$)** family of effect sizes, which represent the proportion of variance accounted for by a particular variable. A variant, **generalized eta squared ($\eta_{G}^{2}$)**, is particularly suited for providing comparable effect sizes in both between and within-subject designs [@Olejnik2003; @Bakeman2005]. This property makes it more easily applicable to meta-analyses.
 
 For those accustomed to Cohen's *d*, it's important to be aware that $\eta_{G}^{2}$ is typically smaller, with a Cohen's d of 0.2 being equivalent to a $\eta_{G}^{2}$ of around 0.02. Also, the actual number has little meaning beyond its scale relative to other effects. 
 

--- a/effectsize_example.Rmd
+++ b/effectsize_example.Rmd
@@ -3,10 +3,8 @@ title: "Effect size"
 output:
   html_document:
     toc: yes
-  html_notebook:
-    toc: yes
     toc_float:
-      collapsed: no
+      collapsed: yes
 bibliography: references.bib
 ---
 

--- a/references.bib
+++ b/references.bib
@@ -130,3 +130,28 @@
 	Bdsk-Url-1 = {doi.org/10.1016/B978-0-12-179060-8.50007-4},
 	Bdsk-Url-2 = {http://dx.doi.org/10.1016/B978-0-12-179060-8.50007-4}}
 
+@article{Baguley2004,
+  author = {Baguley, Thom},
+  doi = {10.1016/j.apergo.2004.01.002},
+  journal = {Applied Ergonomics},
+  keywords = {Applied research,Experimental design,Statistical power},
+  number = {2},
+  pages = {73--80},
+  pmid = {15105068},
+  title = {{Understanding statistical power in the context of applied research}},
+  volume = {35},
+  year = {2004}
+}
+
+@article{Lenth2001,
+  author = {Lenth, Russel V},
+  doi = {10.1198/000313001317098149},
+  journal = {The American Statistician},
+  keywords = {cohen's effect measures,confidence-bounds,equivalence testing,observed power,power,retrospective power,study design},
+  number = {3},
+  pages = {187--193},
+  pmid = {170299300003},
+  title = {{Some practical guidelines for effective sample size determination}},
+  volume = {55},
+  year = {2001}
+}

--- a/references.bib
+++ b/references.bib
@@ -155,3 +155,24 @@
   volume = {55},
   year = {2001}
 }
+
+@article{Baguley2009,
+  author = {Baguley, Thom},
+  doi = {10.1348/000712608X377117},
+  journal = {British journal of psychology},
+  number = {3},
+  pages = {603--617},
+  title = {{Standardized or simple effect size: what should be reported?}},
+  url = {http://www.ncbi.nlm.nih.gov/pubmed/19017432},
+  volume = {100},
+  year = {2009}
+}
+
+@book{APA2001,
+  author = {{American Psychological Association}},
+  edition = {5th Editio},
+  isbn = {1557987904},
+  pages = {400},
+  title = {{Publication Manual of the American Psychological Association}},
+  year = {2001}
+}

--- a/references.bib
+++ b/references.bib
@@ -1,33 +1,21 @@
-%% This BibTeX bibliography file was created using BibDesk.
-%% http://bibdesk.sourceforge.net/
-
-%% Created for Chat at 2017-05-10 09:34:46 -0600 
-
-
 %% Saved with string encoding Unicode (UTF-8) 
 
 
 
 @article{Olejnik2003,
 	Author = {Stephen Olejnik and James Algina},
-	Date-Added = {2017-06-16 11:00:05 +0000},
-	Date-Modified = {2017-06-16 11:00:39 +0000},
 	Journal = {Psychological Methods},
 	Title = {Generalized eta and omega squared statistics: measures of effect size for some common research designs},
 	Year = {2003}}
 
 @article{Bakeman2005,
 	Author = {Roger Bakeman},
-	Date-Added = {2017-06-16 10:59:24 +0000},
-	Date-Modified = {2017-06-16 11:00:02 +0000},
 	Journal = {Behavior Research Methods},
 	Title = {Recommended effect size statistics for repeated measures designs},
 	Year = {2005}}
 
 @book{Rosenthal1991a,
 	Author = {Rosenthal, Robert},
-	Date-Added = {2017-05-10 15:18:14 +0000},
-	Date-Modified = {2017-05-10 15:18:19 +0000},
 	Publisher = {Sage},
 	Title = {Meta-analytic procedures for social research},
 	Volume = {6},
@@ -35,8 +23,6 @@
 
 @book{Cohen1988a,
 	Author = {Cohen, Jacob},
-	Date-Added = {2017-05-10 14:06:14 +0000},
-	Date-Modified = {2017-05-10 14:06:14 +0000},
 	Pages = {20--26},
 	Publisher = {Lawrence Earlbaum Associates},
 	Title = {Statistical power analysis for the behavioral sciences},
@@ -44,16 +30,12 @@
 
 @book{Cumming2013a,
 	Author = {Cumming, Geoff},
-	Date-Added = {2017-05-10 13:46:15 +0000},
-	Date-Modified = {2017-05-10 14:05:24 +0000},
 	Publisher = {Routledge},
 	Title = {Understanding the new statistics: Effect sizes, confidence intervals, and meta-analysis},
 	Year = {2013}}
 
 @article{Cumming2014a,
 	Author = {Geoff Cumming},
-	Date-Added = {2017-05-10 13:46:09 +0000},
-	Date-Modified = {2017-05-10 13:46:09 +0000},
 	Doi = {10.1177/0956797613504966},
 	Eprint = {http://dx.doi.org/10.1177/0956797613504966},
 	Journal = {Psychological Science},
@@ -68,8 +50,6 @@
 
 @article{Wilkinson1999a,
 	Author = {Wilkinson, Leland},
-	Date-Added = {2017-05-10 13:46:05 +0000},
-	Date-Modified = {2017-05-10 13:46:05 +0000},
 	Journal = {American psychologist},
 	Number = {8},
 	Pages = {594},
@@ -82,17 +62,13 @@
 	Author = {Cummings, Peter},
 	Doi = {10.1001/archpediatrics.2011.97},
 	Journal = {Archives of Pediatrics {\&} Adolescent Medicine},
-	Mendeley-Groups = {stats/effect sizes},
 	Month = {jul},
 	Number = {7},
 	Pages = {592},
-	Pmid = {21727271},
 	Title = {{Arguments for and Against Standardized Mean Differences (Effect Sizes)}},
 	Url = {http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve{\&}db=PubMed{\&}dopt=Citation{\&}list{\_}uids=21727271 http://archpedi.jamanetwork.com/article.aspx?doi=10.1001/archpediatrics.2011.97},
 	Volume = {165},
-	Year = {2011},
-	Bdsk-Url-1 = {http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve%7B%5C&%7Ddb=PubMed%7B%5C&%7Ddopt=Citation%7B%5C&%7Dlist%7B%5C_%7Duids=21727271%20http://archpedi.jamanetwork.com/article.aspx?doi=10.1001/archpediatrics.2011.97},
-	Bdsk-Url-2 = {http://dx.doi.org/10.1001/archpediatrics.2011.97}}
+	Year = {2011}}
 
 @article{loftus1993picture,
   title={A picture is worth a thousandp values: On the irrelevance of hypothesis testing in the microcomputer age},
@@ -121,14 +97,11 @@
 	Booktitle = {Statistical Power Analysis for the Behavioral Sciences},
 	Doi = {10.1016/B978-0-12-179060-8.50007-4},
 	Edition = {Revised Ed},
-	Mendeley-Groups = {stats/effect sizes},
 	Pages = {19--74},
 	Publisher = {Academic Press},
 	Title = {{The t Test for Means}},
 	Url = {doi.org/10.1016/B978-0-12-179060-8.50007-4},
-	Year = {1977},
-	Bdsk-Url-1 = {doi.org/10.1016/B978-0-12-179060-8.50007-4},
-	Bdsk-Url-2 = {http://dx.doi.org/10.1016/B978-0-12-179060-8.50007-4}}
+	Year = {1977}}
 
 @article{Baguley2004,
   author = {Baguley, Thom},
@@ -150,7 +123,6 @@
   keywords = {cohen's effect measures,confidence-bounds,equivalence testing,observed power,power,retrospective power,study design},
   number = {3},
   pages = {187--193},
-  pmid = {170299300003},
   title = {{Some practical guidelines for effective sample size determination}},
   volume = {55},
   year = {2001}


### PR DESCRIPTION
This basically pulls in the merged version of my and Pierre's FAQ text that Pierre created on his branch, plus cleans up some citation stuff.

Minor note: `[@Foo1978, @Bar1821]` renders incorrectly; the markdown citation syntax requires a semi-colon for multiple citations: `[@Foo1978; @Bar1821]`. I've fixed the couple of instances of that in this file.

If two reviewers approve I'll merge.