### PR TITLE
Configuration for Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,10 @@
 
 # output
 *.html
+!docs/*.html
 
 # Misc
-*~
 _book
 _bookdown_files
 _main.rds
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: r
+cache: packages
+env:
+  global:
+  - secure: fqWe9XV/C7UDP+1QBjfhuZAyvw4bOQa5DMYQVlHM5nDaX+qA9J8azEp16j44pPaxTVqzRCXZXfjImtSsqxskkOL4Gwzu0im7b5Yxj9XavR30H0BtB0EKyxIvsPLOqycbM+qguhPHyoXSXRuFbktUsqESpqaVjzLj7PyFni0nE65KekCKiuTouSmCgHB83T2f8/aa9mPGQOuHC4BBkWEWymmWd3H7x58lV10FAnZbicxQJ+YSdx9BUFWsgZ6ffwr0UsHjArp5pJyXJxOmG/JkTIN7/l4eoorHKt/9X45Z9bI73ZVayUeU8RDeNGc3TMnxxbEnMFQHw3/ATjKm1kOcMVy/J5hBf8PP5qfj675vwrc18UhVSjLxJf+dtdhTFfHFzIOw2/UHnb1zTuafmylgtwTulFPPRElz5eX0lHFQc4YsL64olfDYv8hx0N3qxRkyWoHuXlpfcA8qOJr71Pkvg8qPkmKOSw2H386JqucjFX9xS5937UvF1vefGhS/ujWqyJ1MGS+MI4GZQ3hUIVFI5tBlzXBF1yaSDoPd2yDaYKIxxAVkSsKhi+n3QEthVM/bDqZgBYeuX+lGgmRABJnqYuGQcaPtPfhOM6/2UlZ3a7mdjH8Aq5juHAPPgYqNmlnsUkJyQM4bOoq18uv7KaK917DyTwv4n+FkZ64tYTIt7O8=
+before_script:
+- chmod +x ./_build.sh
+- chmod +x ./_deploy.sh
+script:
+- ./_build.sh
+- ./_deploy.sh
+sudo: false
+cache:
+  packages: yes
+  directories:
+    - $TRAVIS_BUILD_DIR/_bookdown_files
+r_github_packages:
+- rstudio/bookdown
+- mjskay/tidybayes
+r_packages:
+- tidyverse
+- forcats
+- broom
+- ggstance
+- Cairo
+- effsize
+- coin
+- afex
+- tidybayes
+- import

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,3 @@
+Package: placeholder for Travis to install required packages
+Title: Does not matter.
+Version: 0.0.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Transparent Statistics in HCI Guidelines
 [![license: CC-BY 4.0 / MIT](https://img.shields.io/badge/license-CC--BY%204.0%20%2F%20MIT-blue.svg)](LICENSE.md)
+[![Build Status](https://travis-ci.org/chatchavan/guidelines.svg?branch=effect-size)](https://travis-ci.org/chatchavan/guidelines)
 
 ## How to use this repository
 

--- a/_build.sh
+++ b/_build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"

--- a/_deploy.sh
+++ b/_deploy.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+#[ -z "${GITHUB_PAT}" ] && exit 0
+#[ "${TRAVIS_BRANCH}" != "master" ] && exit 0
+
+git config --global user.email "robot@transparentstatistics.org"
+git config --global user.name "Robot"
+
+git clone -b gh-pages https://${GITHUB_PAT}@github.com/${TRAVIS_REPO_SLUG}.git book-output
+cd book-output
+cp -r ../_book/* ./
+git add --all *
+git commit -m"Update the book" || true
+git push -q origin gh-pages


### PR DESCRIPTION
**DO NOT MERGE THIS COMMIT: Specific modifications are needed to make it works on the transparentstats/master**

From: https://github.com/transparentstats/guidelines/issues/16

The following is the configuration for Travis CI. It is configured specifically for [my fork](https://github.com/chatchavan/guidelines/tree/effect-size). You can find the output compiled by Travis [here](https://chatchavan.github.io/guidelines/).

Decision made:

- Required libraries are listed in `.travis.yml` instead of `DESCRIPTION` because Travis doesn't correctly install github-based packages when I specified them in the `DESCRIPTION` file.
- The compiled result will be put in the `gh-pages` branch with the `Robot<robot@transparentstatistics.org>` user name


TODOs:
- Wiki
   - [ ] Add required packages to `.travis.yml`.

I'll wait for the following before configure the Travis CI for the transparentstats/master branch:

- [ ] Two approvals
- [ ] Effect size is merged back to the master
