### PR TITLE
Make bold text work again

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,7 +5,3 @@ h1, h2, h3, h4, h5, h6 {
 h1.title {
   font-weight: 700;
 }
-
-.book .book-body .page-wrapper .page-inner section.normal strong {
-  font-weight: 500;
-}


### PR DESCRIPTION
A line in `style.css` was resetting the `font-weight` on `<strong>` tags such that they did not look any different from body text; removing it.